### PR TITLE
feat: add the ability to comment on PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
-FROM italia/publiccode-parser-go:latest
+FROM bfabio/publiccode-parser-go:latest
 
-ENTRYPOINT ["/pcvalidate"]
+RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bfabio/publiccode-parser-go:latest
+FROM italia/publiccode-parser-go:alpha
 
 RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -31,6 +31,31 @@ jobs:
         publiccode: 'publiccode.yml' # relative path to your publiccode.yml
 ```
 
+### Comments in PR
+
+This action can reports results in PR comments using the `comment-on-pr`
+parameter.
+
+Note that you need the GitHub token in the `REVIEWDOG_GITHUB_API_TOKEN`
+environment variable:
+
+```yml
+on: [pull_request]
+
+jobs:
+  publiccode_validation:
+    runs-on: ubuntu-latest
+    name: publiccode validation
+    steps:
+    - uses: actions/checkout@v2
+    - uses: italia/publiccode-parser-action@v0.0.2-alpha
+      with:
+        publiccode: 'publiccode.yml'
+        comment-on-pr: true
+      env:
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
+```
+
 ## Contributing
 
 Contributing is always appreciated.

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'publiccode.yml path'
     required: true
     default: 'publiccode.yml'
+  comment-on-pr:
+    description: 'publiccode.yml path'
+    required: false
+    default: "false"
 outputs:
   validation:
     description: 'publiccode.yml validation output'
@@ -18,3 +22,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.publiccode }}
+    - ${{ inputs.comment-on-pr }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -o pipefail
+
+# comment-on-pr parameter from the action
+if [ "$2" == "true" ]; then
+    pcvalidate "$1" | reviewdog -efm="%f:%l:%c: %m" -reporter=github-pr-review -tee
+else
+    pcvalidate "$1"
+fi


### PR DESCRIPTION
Add the comment-on-pr input (false by default) that makes the
action comment on PRs when the validation fails.