### PR TITLE
feat: support v0.3.0 of the Standard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM italia/publiccode-parser-go:alpha
+FROM italia/publiccode-parser-go:v3.0.1
 
 RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -o pipefail
 
 # comment-on-pr parameter from the action
 if [ "$2" == "true" ]; then
-    pcvalidate "$1" | reviewdog -efm="%f:%l:%c: %m" -reporter=github-pr-review -tee
+    pcvalidate "$1" | reviewdog -efm="%f:%l:%c: %t%*[^:]: %m" -reporter=github-pr-review -tee
 else
     pcvalidate "$1"
 fi


### PR DESCRIPTION
Support v0.3.0 of the Standard
(https://github.com/publiccodeyml/publiccode.yml/releases/tag/v0.3.0)
by using publiccode-parser-go v3.0.0.

Also, make use of warnings implemented by publiccode-parser-go v3.0.0.