### PR TITLE
feat: use publiccode-parser-go v4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM italia/publiccode-parser-go:v3.1.3
+FROM italia/publiccode-parser-go:v4.1.0
 
 RUN wget -O - https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Use publiccode-parser-go v4.1.0, which supports v0.4.0 publiccode.yml files.